### PR TITLE
test: add vitest testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Run `yarn install && yarn build` to build and deploy the script.
 
 To build the lite version, run `yarn build:lite` instead.
 
+## Development
+
+- `yarn test` — run tests
+- `yarn lint` — run linting (also runs automatically before build)
+
 ## How to Use
 
 Access it from the `Extensions` menu in the menu bar, or use the keyboard shortcut <kbd>Shift–Command–V</kbd>.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,9 @@ import parserTs from '@typescript-eslint/parser';
 
 export default [
   {
+    ignores: ['vitest.config.ts'],
+  },
+  {
     files: ['**/*.ts'],
     languageOptions: {
       parser: parserTs,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.0",
   "description": "Markdown preview for MarkEdit.",
   "scripts": {
+    "test": "vitest run",
     "lint": "eslint . --config eslint.config.mjs",
     "build": "yarn lint && vite build",
     "build:lite": "cross-env LITE_BUILD=true vite build",
@@ -27,7 +28,8 @@
     "markedit-vite": "https://github.com/MarkEdit-app/MarkEdit-vite#v0.4.0",
     "typescript": "^5.0.0",
     "vite": "^7.0.0",
-    "vite-plugin-singlefile": "^2.2.0"
+    "vite-plugin-singlefile": "^2.2.0",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "katex": "^0.16.33",

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { renderMarkdown } from './render';
+
+// Wait for async imports to complete (highlight.js, katex)
+beforeAll(async () => {
+  // Give time for dynamic imports to resolve
+  await new Promise(resolve => setTimeout(resolve, 500));
+});
+
+describe('renderMarkdown', () => {
+  describe('code blocks without language specifier', () => {
+    it('should NOT apply syntax highlighting classes', () => {
+      const md = '```\nNATURAL ENGLAND\n```';
+      const html = renderMarkdown(md);
+      // Should NOT contain hljs classes
+      expect(html).not.toMatch(/class="[^"]*hljs/);
+    });
+
+    it('should render plain text without keyword highlighting', () => {
+      const md = '```\nOR trigger within\n```';
+      const html = renderMarkdown(md);
+      // Should NOT contain hljs-keyword or similar
+      expect(html).not.toMatch(/hljs-keyword|hljs-built_in|hljs-type/);
+    });
+
+    it('should properly escape HTML in plain code blocks', () => {
+      const md = '```\n<script>alert("xss")</script>\n```';
+      const html = renderMarkdown(md);
+      // Should NOT have hljs classes when no language specified
+      expect(html).not.toMatch(/class="[^"]*hljs/);
+      // Should still escape HTML properly (not execute scripts)
+      expect(html).not.toContain('<script>alert("xss")</script>');
+    });
+  });
+
+  describe('code blocks WITH language specifier', () => {
+    it('should apply syntax highlighting for javascript', () => {
+      const md = '```javascript\nconst x = 1;\n```';
+      const html = renderMarkdown(md);
+      // Should contain hljs classes
+      expect(html).toMatch(/class="[^"]*hljs/);
+    });
+
+    it('should apply syntax highlighting for python', () => {
+      const md = '```python\ndef foo():\n    pass\n```';
+      const html = renderMarkdown(md);
+      // Should contain hljs classes
+      expect(html).toMatch(/class="[^"]*hljs/);
+    });
+  });
+
+  describe('mermaid blocks', () => {
+    it('should render as mermaid div', () => {
+      const md = '```mermaid\ngraph TD\n```';
+      const html = renderMarkdown(md);
+      expect(html).toContain('<div class="mermaid">');
+    });
+
+    it('should not apply hljs classes to mermaid blocks', () => {
+      const md = '```mermaid\ngraph TD\n    A --> B\n```';
+      const html = renderMarkdown(md);
+      expect(html).not.toMatch(/class="[^"]*hljs/);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  define: {
+    __PKG_VERSION__: JSON.stringify('test'),
+    __FULL_BUILD__: JSON.stringify(true),
+  },
+});


### PR DESCRIPTION
## Summary

Adds vitest testing infrastructure for the MarkEdit-preview project.

- Adds `vitest` as a dev dependency with `yarn test` script
- Adds `vitest.config.ts` with `__PKG_VERSION__` and `__FULL_BUILD__` defines
- Adds `src/render.test.ts` with tests for `renderMarkdown`:
  - Code blocks without language specifier get no hljs classes (since `syntaxAutoDetect` defaults to `false`)
  - Code blocks with a language specifier get hljs highlighting
  - Mermaid blocks render as `<div class="mermaid">`
  - HTML is properly escaped in plain code blocks
- Adds vitest config to eslint ignores
- Adds Development section to README

## Test plan

- [x] `yarn test` — 7 tests pass
- [x] `yarn lint` — passes
- [x] `yarn build` — succeeds
- [x] No changes to `src/render.ts` or `src/settings.ts`