### PR TITLE
Add defaultMode setting for startup view mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ In [settings.json](https://github.com/MarkEdit-app/MarkEdit/wiki/Customization#a
 ```json
 {
   "extension.markeditPreview": {
+    "defaultMode": "side-by-side",
     "autoUpdate": true,
     "syncScroll": true,
     "hidePreviewButtons": true,
@@ -67,6 +68,7 @@ In [settings.json](https://github.com/MarkEdit-app/MarkEdit/wiki/Customization#a
 }
 ```
 
+- `defaultMode`: The view mode to always start in. Valid values: `edit`, `side-by-side` (default), `preview`.
 - `autoUpdate`: Whether to enable automatic update checks.
 - `syncScroll`: Whether to enable scroll synchronization.
 - `hidePreviewButtons`: Whether to hide the built-in preview buttons (not applicable for lite build).

--- a/main.ts
+++ b/main.ts
@@ -76,13 +76,6 @@ MarkEdit.onEditorReady(async() => {
     restoreViewMode();
   }
 
-  if (typeof MarkEdit.getFileInfo === 'function') {
-    const isDraft = (await MarkEdit.getFileInfo())?.filePath === undefined;
-    if (isDraft && MarkEdit.editorAPI.getText().length === 0) {
-      setViewMode(ViewMode.edit, false);
-    }
-  }
-
   renderHtmlPreview();
   startObserving(getEditPane(), getPreviewPane());
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,7 @@ export const styledHtmlColorScheme = (rootValue.styledHtmlColorScheme ?? rootVal
 export const mathDelimiters = rootValue.mathDelimiters;
 export const previewModes = (changeMode.modes ?? Constants.defaultModes) as string[];
 export const keyboardShortcut = toObject(changeMode.hotKey);
+export const defaultMode = (rootValue.defaultMode ?? 'side-by-side') as string;
 export const markdownItPreset = (markdownIt.preset ?? Constants.defaultPreset) as PresetName;
 export const markdownItOptions = toObject(markdownIt.options);
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,7 +2,7 @@ import { MarkEdit } from 'markedit-api';
 import { appendStyle, getFileName, selectFullRange } from './utils';
 import { renderMarkdown, handlePostRender, applyStyles } from './render';
 import { replaceImageURLs } from './image';
-import { hidePreviewButtons, previewModes } from './settings';
+import { defaultMode, hidePreviewButtons, previewModes } from './settings';
 import { localized } from './strings';
 import { syncScrollProgress } from './scroll';
 
@@ -124,13 +124,7 @@ export function changeViewMode() {
   // Get the rotation of all modes, "edit" always goes first
   const rotation = [
     ViewMode.edit,
-    ...previewModes.map(mode => {
-      switch (mode) {
-        case 'side-by-side': return ViewMode.sideBySide;
-        case 'preview': return ViewMode.preview;
-        default: return undefined;
-      }
-    }).filter(mode => mode !== undefined),
+    ...previewModes.map(parseViewMode).filter(mode => mode !== undefined),
   ];
 
   // When current mode is not found in the rotation, start over from "edit"
@@ -140,9 +134,18 @@ export function changeViewMode() {
 }
 
 export function restoreViewMode() {
-  const initalMode = localStorage.getItem(Constants.viewModeCacheKey);
-  if (initalMode !== null) {
-    setViewMode(Number(initalMode), false);
+  const mode = parseViewMode(defaultMode);
+  if (mode !== undefined) {
+    setViewMode(mode, false);
+  }
+}
+
+function parseViewMode(mode: string): ViewMode | undefined {
+  switch (mode) {
+    case 'edit': return ViewMode.edit;
+    case 'side-by-side': return ViewMode.sideBySide;
+    case 'preview': return ViewMode.preview;
+    default: return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a `defaultMode` setting that lets users choose which view mode the extension always starts in.

- Valid values: `edit`, `side-by-side` (default), `preview`
- Defaults to `side-by-side`, since users who install a preview extension likely want previews
- Replaces the previous empty-draft guard and cached preference logic with a single, predictable setting

## Changes

- `src/settings.ts` — export new `defaultMode` setting, defaulting to `side-by-side`
- `src/view.ts` — `restoreViewMode()` uses `defaultMode` directly; extracted `parseViewMode()` to share the string-to-enum mapping with `changeViewMode()`
- `main.ts` — remove empty-draft guard (now redundant)
- `README.md` — document the new setting