### PR TITLE
Make preview overlay's inset configurable via CSS variable

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -31,10 +31,7 @@
 
 .markdown-body.overlay {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: var(--markedit-content-inset-left, 0);
+  inset: var(--markedit-content-inset, 0);
   display: block;
   z-index: 10000;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -31,7 +31,10 @@
 
 .markdown-body.overlay {
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: var(--markedit-content-inset-left, 0);
   display: block;
   z-index: 10000;
 }


### PR DESCRIPTION
## Why

Third-party plugins that occupy a slice on the left edge of the viewport (e.g. a TOC sidebar) can't currently coexist with preview-only mode: `.markdown-body.overlay` uses `position: absolute; inset: 0` against the viewport, ignoring any `padding-inline-start` on `body`. The only workaround is `!important` overrides targeting preview's class names, which is fragile.

Concrete example — my outline plugin currently ships with this compatibility shim:

https://github.com/gpolitis/MarkEdit-outline/blob/2cbbea0bb99de604a5a1cf73862155bcb95e8ee3/markedit-outline.js#L164-L170

The shim works but couples the two plugins via class-name targeting, which silently breaks if either side renames a class.

## What

Replace `inset: 0` with explicit per-side values, reading `left` from a CSS custom property with a `0` fallback:

```css
left: var(--markedit-content-inset-left, 0);
```

A plugin that claims a left slice declares the variable on `body` when active:

```css
body.my-plugin-active {
  --markedit-content-inset-left: 268px;
}
```

CSS custom properties cascade through the DOM, so preview's overlay pane picks it up automatically.

## Backward compatibility

When no plugin sets the variable, `0` is used and the layout is byte-identical to today. No other selectors changed.

## Scope

Scoped to `left` only since that's the only side affected today. If future plugins need other edges, mirror variables for `top`/`right`/`bottom` are a natural addition — leaving that for when there's a concrete use case.