### PR TITLE
Adjust control position in Quick Look

### DIFF
--- a/dist/lite/markedit-preview.js
+++ b/dist/lite/markedit-preview.js
@@ -1997,8 +1997,8 @@ ${r}`}async function dr(e=!0){const n=H.MarkEdit.editorAPI.getText();return awai
   }
 
   .quicklook-toolbar {
-    top: 6px;
-    right: 6px;
+    top: 8px;
+    right: 16px;
     left: auto;
     height: auto;
     background: transparent !important;

--- a/dist/markedit-preview.js
+++ b/dist/markedit-preview.js
@@ -2248,8 +2248,8 @@ ${r}`}async function Jw(t=!0){const e=Yr.MarkEdit.editorAPI.getText();{const r=a
   }
 
   .quicklook-toolbar {
-    top: 6px;
-    right: 6px;
+    top: 8px;
+    right: 16px;
     left: auto;
     height: auto;
     background: transparent !important;

--- a/styles/quicklook.css
+++ b/styles/quicklook.css
@@ -131,8 +131,8 @@ body {
   }
 
   .quicklook-toolbar {
-    top: 6px;
-    right: 6px;
+    top: 8px;
+    right: 16px;
     left: auto;
     height: auto;
     background: transparent !important;


### PR DESCRIPTION
MarkEdit native app intercepts mouse events, this change makes buttons easier to click.