### PR TITLE
Add "themeName": "auto" to follow the app theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ In [settings.json](https://github.com/MarkEdit-app/MarkEdit/wiki/Customization#a
 - `syntaxAutoDetect`: Whether to enable automatic language detection for syntax highlighting in code blocks (not applicable for lite build).
 - `imageHoverPreview`: Whether to enable image preview on hover.
 - `inlineImages`: Whether Mixed mode replaces image links with inline images.
-- `themeName`: Set the preview color theme, available themes can be found in the [`styles/themes`](styles/themes) folder. Use `"none"` to disable preview styling and render the raw HTML.
+- `themeName`: Set the preview color theme, available themes can be found in the [`styles/themes`](styles/themes) folder. Use `"auto"` to follow the app's current theme (every built-in app theme has a preview counterpart, and a dark app theme keeps the preview dark regardless of the system appearance). Use `"none"` to disable preview styling and render the raw HTML.
 - `styledHtmlColorScheme`: Determine the color scheme of saving styled html files, valid values are `light`, `dark`, and `auto`.
 - `mathDelimiters`: Customize math delimiters for KaTeX rendering (not applicable for lite build), each delimiter object has `left`, `right`, and `display` properties, defaults to `$...$`, `$$...$$`, `\(...\)`, and `\[...\]`.
 - `changeMode.modes`: Define the ordered rotation for the "Change Mode" feature using `edit`, `syntax-hidden`, `side-by-side`, and `preview`. If neither editor mode is included, `edit` is added automatically.

--- a/src/features/search.ts
+++ b/src/features/search.ts
@@ -1,6 +1,6 @@
 import Mark from 'mark.js';
 import { currentViewMode, getPreviewPane, ViewMode } from '../view';
-import { themeName } from '../support/settings';
+import { currentTheme } from '../support/settings';
 
 const MARK_MATCH_CLASS = 'markedit-preview-mark';
 const MARK_HIGHLIGHTED_CLASS = 'markedit-preview-mark-highlighted';
@@ -168,7 +168,7 @@ function updateStyles() {
     document.head.appendChild(markStyleSheet);
   }
 
-  const { light, dark } = searchMatchColors[themeName] ?? searchMatchColors['github'];
+  const { light, dark } = searchMatchColors[currentTheme().name] ?? searchMatchColors['github'];
   markStyleSheet.textContent = [
     `.${MARK_MATCH_CLASS} { background: ${light} !important; color: inherit !important; }`,
     `.${MARK_HIGHLIGHTED_CLASS} { background: #ffff00 !important; color: #000000 !important; border-radius: 2px; box-shadow: 0px 0px 0px 2px #ffff00, 0px 0px 3px 2px rgba(0, 0, 0, 0.4); }`,

--- a/src/styling.ts
+++ b/src/styling.ts
@@ -1,5 +1,5 @@
 import { extractBackgroundColor } from './shared/utils';
-import { themeName, showRawHtml } from './support/settings';
+import { currentTheme, showRawHtml } from './support/settings';
 import type { ColorScheme } from './shared/types';
 
 import githubBase from '../styles/themes/github/base.css?raw';
@@ -60,12 +60,30 @@ const previewThemes: Record<string, ThemeVariants> = {
   'xcode': { light: xcodeLight, dark: xcodeDark },
 };
 
+/**
+ * The variants of the theme in use, resolving `"auto"` against the app theme.
+ */
+function activeVariants(): ThemeVariants {
+  const { name } = currentTheme();
+  return previewThemes[name] ?? previewThemes['github'];
+}
+
+/**
+ * For `"auto"` theming, the app theme pins the color scheme (e.g. `xcode-dark`
+ * stays dark under a light system appearance); explicit schemes pass through.
+ */
+function pinColorScheme(colorScheme: ColorScheme): ColorScheme {
+  const { scheme } = currentTheme();
+  return colorScheme === 'auto' && scheme !== undefined ? scheme : colorScheme;
+}
+
 export function coreCss(colorScheme: ColorScheme = 'auto') {
   if (showRawHtml) {
     return '';
   }
 
-  const variants = previewThemes[themeName] ?? previewThemes['github'];
+  colorScheme = pinColorScheme(colorScheme);
+  const variants = activeVariants();
   const lightVariant = variants.light ?? variants.dark;
   const darkVariant = variants.dark ?? variants.light;
   const lightBackground = extractBackgroundColor(lightVariant) ?? '#ffffff';
@@ -89,7 +107,8 @@ export function previewThemeCss(colorScheme: ColorScheme = 'auto') {
     ].join('\n');
   }
 
-  const variants = previewThemes[themeName] ?? previewThemes['github'];
+  colorScheme = pinColorScheme(colorScheme);
+  const variants = activeVariants();
   const light = (variants.light ?? variants.dark) as string;
   const dark = (variants.dark ?? variants.light) as string;
 
@@ -104,14 +123,14 @@ export function previewThemeCss(colorScheme: ColorScheme = 'auto') {
 export function alertsCss(colorScheme: ColorScheme = 'auto') {
   const styles = [
     alertsBase,
-    ...createCss(colorScheme, alertsLight, alertsDark),
+    ...createCss(pinColorScheme(colorScheme), alertsLight, alertsDark),
   ];
 
   return styles.join('\n');
 }
 
 export function hljsCss(colorScheme: ColorScheme = 'auto') {
-  return createCss(colorScheme, hljsBase, hljsDark).join('\n');
+  return createCss(pinColorScheme(colorScheme), hljsBase, hljsDark).join('\n');
 }
 
 export function codeCopyCss() {

--- a/src/support/settings.ts
+++ b/src/support/settings.ts
@@ -38,7 +38,29 @@ export const syntaxAutoDetect = toBoolean(rootValue.syntaxAutoDetect, false);
 export const imageHoverPreview = toBoolean(rootValue.imageHoverPreview, false);
 export const inlineImages = toBoolean(rootValue.inlineImages, false);
 export const themeName = (rootValue.themeName ?? 'github') as string;
+export const isAutoTheme = themeName === 'auto';
 export const showRawHtml = themeName === 'none';
+
+/**
+ * The theme to use right now. For `"themeName": "auto"`, it follows the app's
+ * current theme via `MarkEdit.editorConfig.theme`: the `-light`/`-dark`/`-dawn`
+ * suffix maps to the theme's base name and pins the color scheme, so a dark
+ * editor theme keeps the preview dark regardless of the system appearance.
+ */
+export function currentTheme(): { name: string; scheme?: Exclude<ColorScheme, 'auto'> } {
+  if (!isAutoTheme) {
+    return { name: themeName };
+  }
+
+  const appTheme = ((MarkEdit.editorConfig as { theme?: unknown }).theme ?? 'github-light') as string;
+  const match = /^(.+?)(?:-(light|dark|dawn))?$/.exec(appTheme);
+  const suffix = match?.[2];
+  return {
+    name: match?.[1] ?? 'github',
+    // Suffix-less app themes (dracula, cobalt, night-owl, ...) are all dark
+    scheme: suffix === 'light' || suffix === 'dawn' ? 'light' : 'dark',
+  };
+}
 export const styledHtmlColorScheme = (rootValue.styledHtmlColorScheme ?? rootValue.styledHtmlTheme ?? 'auto') as ColorScheme; // styledHtmlTheme for backward compatibility
 export const mathDelimiters = rootValue.mathDelimiters;
 export const viewModes = (changeMode.modes ?? Constants.defaultModes) as string[];

--- a/src/view.ts
+++ b/src/view.ts
@@ -3,7 +3,7 @@ import { MarkEdit } from 'markedit-api';
 import { appendStyle, getBlockRange, getFileExtension, getFileName, joinPaths, selectFullRange } from './shared/utils';
 import { renderMarkdown, renderMermaid, renderKatex, handlePostRender, applyStyles } from './render';
 import { replaceImageURLs } from './features/image';
-import { hidePreviewButtons, viewModes } from './support/settings';
+import { hidePreviewButtons, isAutoTheme, viewModes } from './support/settings';
 import { localized } from './shared/strings';
 import { syncScrollProgress } from './scroll';
 import { resolveTaskToggle } from './features/task';
@@ -39,12 +39,12 @@ export enum ViewMode {
 
 export function setUp() {
   appendStyle(mainCss);
-  appendStyle(previewThemeCss());
+  themeStyles = appendStyle(previewThemeCss());
   appendStyle(codeCopyCss());
 
   if (__FULL_BUILD__) {
     import('../styles/katex.css?raw').then(mod => appendStyle(mod.default));
-    appendStyle(hljsCss());
+    hljsStyles = appendStyle(hljsCss());
 
     // Hide the built-in preview buttons in side-by-side mode
     if (hidePreviewButtons) {
@@ -85,6 +85,9 @@ export function setUp() {
   const darkModeObserver = matchMedia('(prefers-color-scheme: dark)');
   darkModeObserver.addEventListener('change', () => {
     updateGutterStyle();
+
+    // The app may switch its theme along with the appearance
+    setTimeout(refreshThemeStyles, 200);
 
     // Re-render mermaid diagrams to apply the new theme
     if (document.querySelector('.mermaid') !== null) {
@@ -197,10 +200,33 @@ export function isEditorOnlyMode() {
   return mode === ViewMode.edit || mode === ViewMode.syntaxHidden;
 }
 
+let themeStyles: HTMLStyleElement | undefined;
+let hljsStyles: HTMLStyleElement | undefined;
+
+/**
+ * With `"themeName": "auto"`, the css depends on the app's current theme,
+ * which can change at runtime; refresh it whenever the preview updates.
+ */
+function refreshThemeStyles() {
+  if (!isAutoTheme) {
+    return;
+  }
+
+  if (themeStyles !== undefined) {
+    themeStyles.textContent = previewThemeCss();
+  }
+
+  if (hljsStyles !== undefined) {
+    hljsStyles.textContent = hljsCss();
+  }
+}
+
 export async function renderHtmlPreview() {
   if (isEditorOnlyMode()) {
     return;
   }
+
+  refreshThemeStyles();
 
   const html = replaceImageURLs(await getRenderedHtml());
   previewPane.innerHTML = html;

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -37,7 +37,7 @@ vi.mock('mark.js', () => ({
   },
 }));
 
-vi.mock('../src/support/settings', () => ({ themeName: 'github' }));
+vi.mock('../src/support/settings', () => ({ themeName: 'github', currentTheme: () => ({ name: 'github' }) }));
 
 vi.mock('../src/view', () => ({
   ViewMode: { edit: 'edit', sideBySide: 'side-by-side', preview: 'preview' },

--- a/tests/theme.auto.test.ts
+++ b/tests/theme.auto.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockState = {
+  appTheme: 'github-light' as string | undefined,
+};
+
+vi.mock('markedit-api', () => ({
+  MarkEdit: {
+    userSettings: { 'extension.markeditPreview': { themeName: 'auto' } },
+    get editorConfig() {
+      return { theme: mockState.appTheme };
+    },
+  },
+}));
+
+import { currentTheme, isAutoTheme } from '../src/support/settings';
+
+beforeEach(() => {
+  mockState.appTheme = 'github-light';
+});
+
+describe('currentTheme with "auto"', () => {
+  test('is recognized as auto', () => {
+    expect(isAutoTheme).toBe(true);
+  });
+
+  test('maps light-suffixed app themes', () => {
+    mockState.appTheme = 'github-light';
+    expect(currentTheme()).toEqual({ name: 'github', scheme: 'light' });
+
+    mockState.appTheme = 'solarized-light';
+    expect(currentTheme()).toEqual({ name: 'solarized', scheme: 'light' });
+
+    mockState.appTheme = 'winter-is-coming-light';
+    expect(currentTheme()).toEqual({ name: 'winter-is-coming', scheme: 'light' });
+  });
+
+  test('maps dark-suffixed app themes', () => {
+    mockState.appTheme = 'xcode-dark';
+    expect(currentTheme()).toEqual({ name: 'xcode', scheme: 'dark' });
+
+    mockState.appTheme = 'minimal-dark';
+    expect(currentTheme()).toEqual({ name: 'minimal', scheme: 'dark' });
+  });
+
+  test('maps rose-pine-dawn to the light variant', () => {
+    mockState.appTheme = 'rose-pine-dawn';
+    expect(currentTheme()).toEqual({ name: 'rose-pine', scheme: 'light' });
+  });
+
+  test('treats suffix-less app themes as dark', () => {
+    for (const name of ['dracula', 'cobalt', 'synthwave84', 'night-owl', 'rose-pine']) {
+      mockState.appTheme = name;
+      expect(currentTheme()).toEqual({ name, scheme: 'dark' });
+    }
+  });
+
+  test('falls back gracefully when the app theme is missing', () => {
+    mockState.appTheme = undefined;
+    expect(currentTheme()).toEqual({ name: 'github', scheme: 'light' });
+  });
+});


### PR DESCRIPTION
Implements #167.

With `"themeName": "auto"`, the preview resolves its theme from the app's current theme (`MarkEdit.editorConfig.theme`) instead of a fixed name:

- The `-light`/`-dark`/`-dawn` suffix is stripped to get the preview theme name — every built-in app theme maps onto an existing preview theme, so no new CSS is needed.
- The suffix also pins the color scheme (applied in `coreCss`/`previewThemeCss`/`alertsCss`/`hljsCss`), so `xcode-dark` keeps the preview dark under a light system appearance. Suffix-less app themes (`dracula`, `cobalt`, `night-owl`, `synthwave84`, `rose-pine`) are treated as dark. `rose-pine-dawn` maps to rose-pine light.
- Since the app theme can change at runtime and there is no change notification for extensions, the theme/hljs style sheets are refreshed on each preview render and (with a small delay, matching the app's own switch) on `prefers-color-scheme` changes. Explicitly configured theme names behave exactly as before.
- Search-match highlight colors follow the resolved theme as well.

Default behavior is unchanged: `themeName` still defaults to `github`, `"none"` still renders raw HTML.

Tests: added `tests/theme.auto.test.ts` covering the mapping (suffixed, suffix-less, `rose-pine-dawn`, missing config). `yarn lint` passes; the full test suite shows the same 15 pre-existing failures as `main` in my environment (Node 26, localStorage-related), with no new ones.